### PR TITLE
change: stack type

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -7,23 +7,26 @@ func evalPostfix(ex []expr) (int, error) {
 		case lit:
 			s.push(c)
 		case op:
-			b, err := s.pop()
+			be, err := s.pop()
 			if err != nil {
 				return -1, err
 			}
-			a, err := s.pop()
+			b, _ := be.(lit)
+			ae, err := s.pop()
 			if err != nil {
 				return -1, err
 			}
+			a, _ := ae.(lit)
 			switch c {
 			case op('+'):
 				s.push(a + b)
 			}
 		}
 	}
-	n, err := s.pop()
+	ne, err := s.pop()
 	if err != nil || !s.empty() {
 		return -1, err
 	}
-	return int(n), nil
+	n, _ := ne.(int)
+	return n, nil
 }

--- a/stack.go
+++ b/stack.go
@@ -7,21 +7,21 @@ import (
 
 type stack struct {
 	lock sync.Mutex
-	s    []lit
+	s    []expr
 }
 
 func newStack() *stack {
-	return &stack{sync.Mutex{}, make([]lit, 0)}
+	return &stack{sync.Mutex{}, make([]expr, 0)}
 }
 
-func (s *stack) push(v lit) {
+func (s *stack) push(v expr) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	s.s = append(s.s, v)
 }
 
-func (s *stack) pop() (lit, error) {
+func (s *stack) pop() (expr, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 


### PR DESCRIPTION
Shunting Yard Algorithmで演算子もStackに突っ込む必要が出てきたので、型を`lit`から`expr`に広げた
