### PR TITLE
add: shuntingyard

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -1,5 +1,51 @@
 package calculator
 
+var precedence = map[op]int{
+	op('+'): 4,
+	op('-'): 4,
+	op('*'): 5,
+	op('/'): 5}
+
+func isHighPrecedence(o1 op, o2 op) bool {
+	return precedence[o1] > precedence[o2]
+}
+
+func shuntingyard(ex []expr) ([]expr, error) {
+	out := make([]expr, 0)
+	s := newStack()
+	for _, e := range ex {
+		switch c := e.(type) {
+		case lit:
+			out = append(out, c)
+		case op:
+			for !s.empty() {
+				r, err := s.top()
+				if err != nil {
+					return nil, err
+				}
+				if !isHighPrecedence(c, r.(op)) {
+					r, err = s.pop()
+					if err != nil {
+						return nil, err
+					}
+					out = append(out, r)
+				} else {
+					break
+				}
+			}
+			s.push(c)
+		}
+	}
+	for !s.empty() {
+		r, err := s.pop()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
 func evalPostfix(ex []expr) (int, error) {
 	s := newStack()
 	for _, e := range ex {

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -5,6 +5,24 @@ import (
 	"testing"
 )
 
+func TestShuntingyard(t *testing.T) {
+	o, err := shuntingyard([]expr{lit(1), op('+'), lit(1)})
+	assert.Nil(t, err)
+	assert.Equal(t, []expr{lit(1), lit(1), op('+')}, o)
+	o, err = shuntingyard([]expr{lit(10), op('+'), lit(2), op('*'), lit(3)})
+	assert.Nil(t, err)
+	assert.Equal(t, []expr{lit(10), lit(2), lit(3), op('*'), op('+')}, o)
+	o, err = shuntingyard([]expr{lit(4), op('/'), lit(2), op('-'), lit(10)})
+	assert.Nil(t, err)
+	assert.Equal(t, []expr{lit(4), lit(2), op('/'), lit(10), op('-')}, o)
+	o, err = shuntingyard([]expr{lit(1), op('+'), lit(2), op('-'), lit(3), op('+'), lit(4)})
+	assert.Nil(t, err)
+	assert.Equal(t, []expr{lit(1), lit(2), op('+'), lit(3), op('-'), lit(4), op('+')}, o)
+	o, err = shuntingyard([]expr{lit(1), op('+')})
+	assert.Nil(t, err)
+	assert.Equal(t, []expr{lit(1), op('+')}, o)
+}
+
 func TestEvalPostfix(t *testing.T) {
 	k, err := evalPostfix([]expr{lit(1), lit(1), op('+')})
 	assert.Nil(t, err)


### PR DESCRIPTION
中置記法を後置記法に変換する

参考: [操車場アルゴリズム](https://ja.wikipedia.org/wiki/%E6%93%8D%E8%BB%8A%E5%A0%B4%E3%82%A2%E3%83%AB%E3%82%B4%E3%83%AA%E3%82%BA%E3%83%A0)